### PR TITLE
Actualización de la liga de arduino logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arduino 1 
 ## Repositorio Prueba
-![Arduino logo](https://github.com/vaniliz/Arduino/blob/master/docs/img/Arduino_Logo.svg.png)
+![Arduino logo](https://vaniliz.github.io/Arduino/docs/img/Arduino_Logo.svg.png)
 
 ### Plataforma
 


### PR DESCRIPTION
Al hacer una página estática sobre el **master branch**, cuando accesas por la página de internet **https://vaniliz.github.io/Arduino/** apunta a **master** de ahí sólo tienes que colocar la misma ruta de directorios hasta llegar al archivo que quieres mostrar, es decir:

> https://vaniliz.github.io/Arduino/docs/img/Arduino_Logo.svg.png 